### PR TITLE
Fix shared memory filesystem for HD cameras

### DIFF
--- a/zm.sh
+++ b/zm.sh
@@ -3,6 +3,8 @@
 # `/sbin/setuser xxxx` runs the given command as the user `xxxx`.
 # If you omit that part, the command will be run as root.
 
+umount /dev/shm
+mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=${MEM:-4096M} tmpfs /dev/shm
 
 sleep 10s
 


### PR DESCRIPTION
Apply fix from hrwebasst/docker-zoneminder, increasing shared mem to
4096M.