### PR TITLE
Update Ubuntu respository URL and use TZ to set up php.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ MAINTAINER Angel Rodriguez  "angel@quantumobject.com"
 RUN echo "deb http://archive.ubuntu.com/ubuntu `cat /etc/container_environment/DISTRIB_CODENAME`-backports main restricted universe" >> /etc/apt/sources.list  \
       && echo "deb http://ppa.launchpad.net/iconnor/zoneminder-master/ubuntu `cat /etc/container_environment/DISTRIB_CODENAME` main" >> /etc/apt/sources.list  \
       && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 776FFB04
+
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends mysql-server  \
                                         libvlc-dev  \
                                         libvlccore-dev\

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if [ -f /etc/configured ]; then
         /sbin/zm.sh&
 else
         #to fix problem with data.timezone that appear at 1.28.108 for some reason
-        sed  -i 's/\;date.timezone =/date.timezone = \"America\/New_York\"/' /etc/php5/apache2/php.ini
+        sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php5/apache2/php.ini
         #configuration for zoneminder
         #trays to fix problem with https://github.com/QuantumObject/docker-zoneminder/issues/22
         chown www-data /dev/shm


### PR DESCRIPTION
By default, php.ini is set to America/New_York, which causes the Zoneminder date/time filters to be off when the local timezone is not New_York.  Container must be launched with TZ variable set properly.

Ubuntu wily has been moved to old-releases.ubuntu.com.