### PR TITLE
[Enhancement] Allow ZoneMinder to run in separates containers and multi server deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,12 @@ RUN echo "deb http://ppa.launchpad.net/iconnor/zoneminder-master/ubuntu `cat /et
                     && rm -rf /tmp/* /var/tmp/*  \
                     && rm -rf /var/lib/apt/lists/*
 
+# to add mysqld deamon to runit
+RUN mkdir -p /etc/service/mysqld /var/log/mysqld ; sync 
+COPY mysqld.sh /etc/service/mysqld/run
+RUN chmod +x /etc/service/mysqld/run \
+    && cp /var/log/cron/config /var/log/mysqld/ \
+    && chown -R mysql /var/log/mysqld
 
 # to add apache2 deamon to runit
 RUN mkdir -p /etc/service/apache2  /var/log/apache2 ; sync 
@@ -62,7 +68,7 @@ RUN cd /usr/src \
     && rm /usr/src/cambozola-latest.tar.gz \
     && rm -R /usr/src/cambozola-0.936
 
-VOLUME /var/cache/zoneminder
+VOLUME /var/backups /var/lib/mysql /var/cache/zoneminder
 # to allow access from outside of the container  to the container service
 # at that ports need to allow access from firewall if need to access it outside of the server. 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #name of container: docker-zoneminder
 #versison of container: 0.5.9
 FROM quantumobject/docker-baseimage:16.04
-MAINTAINER Angel Rodriguez  "angel@quantumobject.com"
+LABEL maintainer="Angel Rodriguez <angel@quantumobject.com>"
 
 ENV TZ America/New_York
 
@@ -10,7 +10,6 @@ ENV TZ America/New_York
 RUN echo "deb http://ppa.launchpad.net/iconnor/zoneminder-master/ubuntu `cat /etc/container_environment/DISTRIB_CODENAME` main" >> /etc/apt/sources.list  \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 776FFB04 \
     && echo $TZ > /etc/timezone && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends mariadb-server \
-
                                         libvlc-dev  \
                                         libvlccore-dev\
                                         libapache2-mod-perl2 \
@@ -23,12 +22,6 @@ RUN echo "deb http://ppa.launchpad.net/iconnor/zoneminder-master/ubuntu `cat /et
                     && rm -rf /tmp/* /var/tmp/*  \
                     && rm -rf /var/lib/apt/lists/*
 
-# to add mysqld deamon to runit
-RUN mkdir -p /etc/service/mysqld /var/log/mysqld ; sync 
-COPY mysqld.sh /etc/service/mysqld/run
-RUN chmod +x /etc/service/mysqld/run \
-    && cp /var/log/cron/config /var/log/mysqld/ \
-    && chown -R mysql /var/log/mysqld
 
 # to add apache2 deamon to runit
 RUN mkdir -p /etc/service/apache2  /var/log/apache2 ; sync 
@@ -41,13 +34,6 @@ RUN chmod +x /etc/service/apache2/run \
 RUN mkdir -p /var/log/zm ; sync 
 COPY zm.sh /sbin/zm.sh
 RUN chmod +x /sbin/zm.sh
-    
-# to add ntp deamon to runit
-RUN mkdir -p /etc/service/ntp  /var/log/ntp ; sync 
-COPY ntp.sh /etc/service/ntp/run
-RUN chmod +x /etc/service/ntp/run \
-    && cp /var/log/cron/config /var/log/ntp/ \
-    && chown -R nobody /var/log/ntp
 
 ##startup scripts  
 #Pre-config scrip that maybe need to be run one time only when the container run the first time .. using a flag to don't 
@@ -75,12 +61,8 @@ RUN cd /usr/src \
     && mv cambozola-0.936/dist/cambozola.jar /usr/share/zoneminder/www  \
     && rm /usr/src/cambozola-latest.tar.gz \
     && rm -R /usr/src/cambozola-0.936
-    
-RUN echo "!/bin/sh ntpdate 0.ubuntu.pool.ntp.org" >> /etc/cron.daily/ntpdate \
-    && chmod 750 /etc/cron.daily/ntpdate
 
-
-VOLUME /var/lib/mysql /var/cache/zoneminder
+VOLUME /var/cache/zoneminder
 # to allow access from outside of the container  to the container service
 # at that ports need to allow access from firewall if need to access it outside of the server. 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-zoneminder
 
-Docker container for [zoneminder v1.31.1][3]
+Docker container for [zoneminder v1.31.44][3]
 
 "ZoneMinder the top Linux video camera security and surveillance solution. ZoneMinder is intended for use in single or multi-camera video security applications, including commercial or home CCTV, theft prevention and child, family member or home monitoring and other domestic care scenarios such as nanny cam installations. It supports capture, analysis, recording, and monitoring of video data coming from one or more video or network cameras attached to a Linux system. ZoneMinder also support web and semi-automatic control of Pan/Tilt/Zoom cameras using a variety of protocols. It is suitable for use as a DIY home video security system and for commercial or professional video security and surveillance. It can also be integrated into a home automation system via X.10 or other protocols. If you're looking for a low cost CCTV system or a more flexible alternative to cheap DVR systems then why not give ZoneMinder a try?"
 
@@ -22,7 +22,7 @@ sudo wget -qO- <https://get.docker.com/> | sh
 To run container use the command below:
 
 ```bash
-docker run -d --shm-size=4096m -p 80:80 quantumobject/docker-zoneminder:1.31.1
+docker run -d --shm-size=4096m -p 80:80 quantumobject/docker-zoneminder:1.31.44
 ```
 
 **  --shm-size=4096m  ==> work only after docker version 1.10
@@ -33,7 +33,7 @@ To run with MySQL in a separate container use the command below:
 docker network create net
 docker run -d -e TZ=America/Argentina/Buenos_Aires -e MYSQL_USER=zmuser -e MYSQL_PASSWORD=zmpass -e MYSQL_DATABASE=zm -e MYSQL_ROOT_PASSWORD=mysqlpsswd -e MYSQL_ROOT_HOST=% --net net --name db mysql/mysql-server:5.7
 echo "wait until MySQL startup..."
-docker run -d -e TZ=America/Argentina/Buenos_Aires -e ZM_DB_HOST=db --net net --name zm -p 80:80 quantumobject/docker-zoneminder:1.31.1
+docker run -d -e TZ=America/Argentina/Buenos_Aires -e ZM_DB_HOST=db --net net --name zm -p 80:80 quantumobject/docker-zoneminder:1.31.44
 ```
 
 ## Set the timezone per environment variable
@@ -100,7 +100,7 @@ services:
        max_attempts: 3
        window: 120s
   web:
-    image: quantumobject/docker-zoneminder:1.31.1
+    image: quantumobject/docker-zoneminder:1.31.44
     networks:
       - net
     volumes:
@@ -125,7 +125,7 @@ services:
     depends_on:
       - db
   stream:
-    image: quantumobject/docker-zoneminder:1.31.1
+    image: quantumobject/docker-zoneminder:1.31.44
     networks:
       - net
     volumes:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Default value is America/New_York .
 
 After that check with your browser at addresses plus the port assigned by docker:
 
-- **<http://host_ip:port/zm/**>
+- <http://host_ip:port/zm/>
 
 Them log in with login/password : admin/admin , Please change password right away and check on-line [documentation][6] to configure zoneminder.
 
@@ -165,13 +165,13 @@ networks:
 ```
 
 above docker-compose.yml stack example asume a directory structure at $PWD as is
-$PWD/mysql (MySQL Data, drwxr-xr-x 6   27 27)
-$PWD/zoneminder (directory for images, drwxrwx--- 5 root 33)
-$PWD/backup (directory for backups, drwxr-xr-x 2 root root)
-$PWD/conf (configuration files, drwxrwxr-x  7 1000 1000, only conf/mysql/my.cnf is required)
-conf/mysql/my.cnf look like:
 
 ```bash
+$PWD/mysql      # (MySQL Data, drwxr-xr-x 6   27 27)
+$PWD/zoneminder # (directory for images, drwxrwx--- 5 root 33)
+$PWD/backup     # (directory for backups, drwxr-xr-x 2 root root)
+$PWD/conf       # (configuration files, drwxrwxr-x  7 1000 1000, only conf/mysql/my.cnf is required)
+cat conf/mysql/my.cnf
 # For advice on how to change settings please see
 # http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
 
@@ -222,7 +222,7 @@ docker service ls
 the image used for the load balancer is modified version of dockercloud/haproxy specially targeted for
 using {{.Task.Slot}} placeholder in DNS name resolution, see more details at
 
-- **<https://github.com/marcelo-ochoa/dockercloud-haproxy.git**>
+- <https://github.com/marcelo-ochoa/dockercloud-haproxy.git>
 
 ## More Info
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ $ sudo wget -qO- <https://get.docker.com/> | sh
 
 To run container use the command below:
 
-$ docker run -d --shm-size=4096m -p 80:80 quantumobject/docker-zoneminder:1.31.1
+```bash
+docker run -d --shm-size=4096m -p 80:80 quantumobject/docker-zoneminder:1.31.1
+```
 
 **  --shm-size=4096m  ==> work only after docker version 1.10
 
 To run with MySQL in a separate container use the command below:
 
-$ docker network create net
-$ docker run -d -e TZ=America/Argentina/Buenos_Aires -e MYSQL_USER=zmuser -e MYSQL_PASSWORD=zmpass -e MYSQL_DATABASE=zm -e MYSQL_ROOT_PASSWORD=mysqlpsswd -e MYSQL_ROOT_HOST=% --net net --name db mysql/mysql-server:5.7
-$ echo "wait until MySQL startup..."
-$ docker run -d -e TZ=America/Argentina/Buenos_Aires -e ZM_DB_HOST=db --net net --name zm -p 80:80 quantumobject/docker-zoneminder:1.31.1
+```bash
+docker network create net
+docker run -d -e TZ=America/Argentina/Buenos_Aires -e MYSQL_USER=zmuser -e MYSQL_PASSWORD=zmpass -e MYSQL_DATABASE=zm -e MYSQL_ROOT_PASSWORD=mysqlpsswd -e MYSQL_ROOT_HOST=% --net net --name db mysql/mysql-server:5.7
+echo "wait until MySQL startup..."
+docker run -d -e TZ=America/Argentina/Buenos_Aires -e ZM_DB_HOST=db --net net --name zm -p 80:80 quantumobject/docker-zoneminder:1.31.1
+```
 
 ## Set the timezone per environment variable
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,16 @@ $ sudo wget -qO- <https://get.docker.com/> | sh
 
 To run container use the command below:
 
-$ docker run -d --shm-size=4096m -p 80 quantumobject/docker-zoneminder
+$ docker run -d --shm-size=4096m -p 80:80 quantumobject/docker-zoneminder:1.31.1
 
 **  --shm-size=4096m  ==> work only after docker version 1.10
+
+To run with MySQL in a separate container use the command below:
+
+$ docker network create net
+$ docker run -d -e TZ=America/Argentina/Buenos_Aires -e MYSQL_USER=zmuser -e MYSQL_PASSWORD=zmpass -e MYSQL_DATABASE=zm -e MYSQL_ROOT_PASSWORD=mysqlpsswd -e MYSQL_ROOT_HOST=% --net net --name db mysql/mysql-server:5.7
+$ echo "wait until MySQL startup..."
+$ docker run -d -e TZ=America/Argentina/Buenos_Aires -e ZM_DB_HOST=db --net net --name zm -p 80:80 quantumobject/docker-zoneminder:1.31.1
 
 ## Set the timezone per environment variable
 
@@ -207,7 +214,7 @@ sql_mode = NO_ENGINE_SUBSTITUTION
 max_connections = 500
 ```
 
-to deploy above stack first initialize your swarm almost with one node for testing
+to deploy above stack first initialize your swarm at least with one node for testing
 
 ```bash
 docker swarm init

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Docker container for [zoneminder v1.31.1][3]
 
 To install docker in Ubuntu 16.04 use the commands:
 
-$ sudo apt-get update
-$ sudo wget -qO- <https://get.docker.com/> | sh
+```bash
+sudo apt-get update
+sudo wget -qO- <https://get.docker.com/> | sh
+```
 
  To install docker in other operating systems check [docker online documentation][4]
 
@@ -66,7 +68,7 @@ $ docker exec -it container_id /bin/bash
 
 ## Docker Swarm deployment
 
-This projects is implemented to be deployed as docker-compose o swarm stack. Here an example of the docker swarm stack
+This projects is implemented to be deployed as docker-compose or swarm stack. Here an example of the docker swarm stack
 
 ```yml
 version: '3.2'
@@ -223,14 +225,14 @@ to deploy above stack first initialize your swarm at least with one node for tes
 ```bash
 docker swarm init
 docker stack deploy -c docker-compose.yml zm
-echo "wait for a few seconds to MySQL start for a first time"
+echo "wait for a few seconds to MySQL start for the first time"
 docker service scale zm_web=1
 echo "go to ZoneMinder console Options-Servers and declare node.0->stream0.localhost and node.1 ... node.3, finally start"
 docker service scale zm_stream=3
 docker service ls
 ```
 
-the image used for the load balancer is modified version of dockercloud/haproxy specially targeted for
+the docker image used for load balancing is a modified version of dockercloud/haproxy specially targeted for
 using {{.Task.Slot}} placeholder in DNS name resolution, see more details at
 
 - <https://github.com/marcelo-ochoa/dockercloud-haproxy.git>

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Docker container for [zoneminder v1.31.1][3]
 
 ## Install dependencies
 
-  - [Docker][2]
+- [Docker][2]
 
 To install docker in Ubuntu 16.04 use the commands:
 
-    $ sudo apt-get update
-    $ sudo wget -qO- https://get.docker.com/ | sh
+$ sudo apt-get update
+$ sudo wget -qO- <https://get.docker.com/> | sh
 
  To install docker in other operating systems check [docker online documentation][4]
 
@@ -19,27 +19,27 @@ To install docker in Ubuntu 16.04 use the commands:
 
 To run container use the command below:
 
-    $ docker run -d --shm-size=4096m -p 80 quantumobject/docker-zoneminder
+$ docker run -d --shm-size=4096m -p 80 quantumobject/docker-zoneminder
 
-**  --shm-size=4096m  ==> work only after docker version 1.10 
+**  --shm-size=4096m  ==> work only after docker version 1.10
 
-## Set the timezone per environment variable:
+## Set the timezone per environment variable
 
     -e TZ=Europe/London
-  
+
 or in yml:
 
   environment:
-  
-     - TZ=Europe/London
-   
-Default value is America/New_York .   
 
-## Accessing the Zoneminder applications:
+     - TZ=Europe/London
+
+Default value is America/New_York .
+
+## Accessing the Zoneminder applications
 
 After that check with your browser at addresses plus the port assigned by docker:
 
-  - **http://host_ip:port/zm/**
+- **<http://host_ip:port/zm/**>
 
 Them log in with login/password : admin/admin , Please change password right away and check on-line [documentation][6] to configure zoneminder.
 
@@ -51,7 +51,178 @@ if timeline fail please check TimeZone at php.ini is the correct one for your se
 
 To access the container from the server that the container is running :
 
-    $ docker exec -it container_id /bin/bash
+$ docker exec -it container_id /bin/bash
+
+## Docker Swarm deployment
+
+This projects is implemented to be deployed as docker-compose o swarm stack. Here an example of the docker swarm stack
+
+```yml
+version: '3.2'
+
+services:
+  db:
+    image: mysql/mysql-server:5.7
+    hostname: db
+    networks:
+      net:
+        aliases:
+          - db
+    volumes:
+      - $PWD/mysql:/var/lib/mysql
+      - $PWD/conf/mysql:/etc/mysql:ro
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - MYSQL_USER=zmuser
+     - MYSQL_PASSWORD=zmpass
+     - MYSQL_DATABASE=zm
+     - MYSQL_ROOT_PASSWORD=mysqlpsswd
+     - MYSQL_ROOT_HOST=%
+    deploy:
+      mode: replicated
+      replicas: 1
+      endpoint_mode: dnsrr
+      restart_policy:
+       condition: on-failure
+       max_attempts: 3
+       window: 120s
+  web:
+    image: quantumobject/docker-zoneminder:1.31.1
+    networks:
+      - net
+    volumes:
+      - /var/empty
+      - $PWD/backups:/var/backups
+      - $PWD/zoneminder:/var/cache/zoneminder
+      - type: tmpfs
+        target: /dev/shm
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - VIRTUAL_HOST=zm.localhost, stream0.localhost
+     - SERVICE_PORTS="80"
+     - ZM_SERVER_HOST=node.0
+     - ZM_DB_HOST=db
+    deploy:
+      mode: replicated
+      replicas: 0
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - db
+  stream:
+    image: quantumobject/docker-zoneminder:1.31.1
+    networks:
+      - net
+    volumes:
+      - /var/empty
+      - $PWD/backups:/var/backups
+      - $PWD/zoneminder:/var/cache/zoneminder
+      - type: tmpfs
+        target: /dev/shm
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - VIRTUAL_HOST=stream{{.Task.Slot}}.localhost
+     - SERVICE_PORTS="80"
+     - ZM_SERVER_HOST=node.{{.Task.Slot}}
+     - ZM_DB_HOST=db
+    deploy:
+      mode: replicated
+      replicas: 0
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - web
+  lb:
+    image: dockercloud/haproxy:1.6.7.1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - target: 80
+        published: 80
+        protocol: tcp
+    networks:
+      - net
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - node0
+networks:
+  net:
+    driver: overlay
+```
+
+above docker-compose.yml stack example asume a directory structure at $PWD as is
+$PWD/mysql (MySQL Data, drwxr-xr-x 6   27 27)
+$PWD/zoneminder (directory for images, drwxrwx--- 5 root 33)
+$PWD/backup (directory for backups, drwxr-xr-x 2 root root)
+$PWD/conf (configuration files, drwxrwxr-x  7 1000 1000, only conf/mysql/my.cnf is required)
+conf/mysql/my.cnf look like:
+
+```bash
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql-files
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+sql_mode = NO_ENGINE_SUBSTITUTION
+max_connections = 500
+```
+
+to deploy above stack first initialize your swarm almost with one node for testing
+
+```bash
+docker swarm init
+docker stack deploy -c docker-compose.yml zm
+echo "wait for a few seconds to MySQL start for a first time"
+docker service scale zm_web=1
+echo "go to ZoneMinder console Options-Servers and declare node.0->stream0.localhost and node.1 ... node.3, finally start"
+docker service scale zm_stream=3
+docker service ls
+```
+
+the image used for the load balancer is modified version of dockercloud/haproxy specially targeted for
+using {{.Task.Slot}} placeholder in DNS name resolution, see more details at
+
+- **<https://github.com/marcelo-ochoa/dockercloud-haproxy.git**>
 
 ## More Info
 

--- a/apache2.sh
+++ b/apache2.sh
@@ -3,8 +3,6 @@
 # `/sbin/setuser www-data` runs the given command as the user `www-data`.
 # If you omit that part, the command will be run as root.
 
-sv -w4 check mysqld
-
 #read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
 #trap "kill -TERM -$pgrp; exit" EXIT TERM KILL SIGKILL SIGTERM SIGQUIT
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Backup mysql
-mysqldump -u root -pmysqlpsswd -h db --all-databases > /var/backups/alldb_backup.sql
+mysqldump -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost} --all-databases > /var/backups/alldb_backup.sql
 
 #Backup important file ... of the configuration ...
 cp  /etc/hosts  /var/backups/

--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Backup mysql
-mysqldump -u root -pmysqlpsswd --all-databases > /var/backups/alldb_backup.sql
+mysqldump -u root -pmysqlpsswd -h db --all-databases > /var/backups/alldb_backup.sql
 
 #Backup important file ... of the configuration ...
 cp  /etc/hosts  /var/backups/

--- a/conf/mysql/my.cnf
+++ b/conf/mysql/my.cnf
@@ -1,0 +1,33 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql-files
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+sql_mode = NO_ENGINE_SUBSTITUTION
+max_connections = 500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# quantumobject/docker-zoneminder:1.31.1 build from https://github.com/marcelo-ochoa/docker-zoneminder
+# quantumobject/docker-zoneminder:1.31.44 build from https://github.com/marcelo-ochoa/docker-zoneminder
+# docker build -t "quantumobject/docker-zoneminder:1.31.44" -f Dockerfile .
 # dockercloud/haproxy:1.6.7.1 build from https://github.com/marcelo-ochoa/dockercloud-haproxy
 version: '3.2'
 
@@ -25,7 +26,7 @@ services:
        max_attempts: 3
        window: 120s
   web:
-    image: quantumobject/docker-zoneminder:1.31.1
+    image: quantumobject/docker-zoneminder:1.31.44
     networks:
       - net
     volumes:
@@ -50,7 +51,7 @@ services:
     depends_on:
       - db 
   stream:
-    image: quantumobject/docker-zoneminder:1.31.1
+    image: quantumobject/docker-zoneminder:1.31.44
     networks:
       - net
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,102 @@
+# quantumobject/docker-zoneminder:1.31.1 build from https://github.com/marcelo-ochoa/docker-zoneminder
+# dockercloud/haproxy:1.6.7.1 build from https://github.com/marcelo-ochoa/dockercloud-haproxy
+version: '3.2'
+
+services:
+  db:
+    image: mysql/mysql-server:5.7
+    networks:
+      - net
+    volumes:
+      - /home/data/zm/mysql:/var/lib/mysql
+      - $PWD/conf/mysql:/etc/mysql:ro
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - MYSQL_USER=zmuser
+     - MYSQL_PASSWORD=zmpass
+     - MYSQL_DATABASE=zm
+     - MYSQL_ROOT_PASSWORD=mysqlpsswd
+     - MYSQL_ROOT_HOST=%
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+       condition: on-failure
+       max_attempts: 3
+       window: 120s
+  web:
+    image: quantumobject/docker-zoneminder:1.31.1
+    networks:
+      - net
+    volumes:
+      - /var/empty
+      - /home/data/zm/backups:/var/backups
+      - /home/data/zm/zoneminder:/var/cache/zoneminder
+      - type: tmpfs
+        target: /dev/shm
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - VIRTUAL_HOST=zm.localhost, stream0.localhost
+     - SERVICE_PORTS="80"
+     - ZM_SERVER_HOST=node.0
+     - ZM_DB_HOST=db
+    deploy:
+      mode: replicated
+      replicas: 0
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - db 
+  stream:
+    image: quantumobject/docker-zoneminder:1.31.1
+    networks:
+      - net
+    volumes:
+      - /var/empty
+      - /home/data/zm/backups:/var/backups
+      - /home/data/zm/zoneminder:/var/cache/zoneminder
+      - type: tmpfs
+        target: /dev/shm
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+     - VIRTUAL_HOST=stream{{.Task.Slot}}.localhost
+     - SERVICE_PORTS="80"
+     - ZM_SERVER_HOST=node.{{.Task.Slot}}
+     - ZM_DB_HOST=db
+    deploy:
+      mode: replicated
+      replicas: 0
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - web
+  lb:
+    image: dockercloud/haproxy:1.6.7.1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - target: 80
+        published: 80
+        protocol: tcp
+    networks:
+      - net
+    environment:
+     - TZ=America/Argentina/Buenos_Aires
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      - web
+networks:
+  net:
+    driver: overlay

--- a/mysqld.sh
+++ b/mysqld.sh
@@ -2,5 +2,9 @@
 ### In mysqld.sh (make sure this file is chmod +x):
 # `chpst -u mysql` runs the given command as the user `mysql`.
 # If you omit that part, the command will be run as root.
+ZM_DB_HOST=${ZM_DB_HOST:-localhost}
 
-exec chpst -u mysql /usr/bin/mysqld_safe  2>&1 
+# IF ZM_DB_HOST is set to localhost, start MySQL local. If not MySQL is running in a separate container
+if [ "$ZM_DB_HOST" == "localhost" ]; then
+  exec chpst -u mysql /usr/bin/mysqld_safe  2>&1 
+fi

--- a/pre-conf.sh
+++ b/pre-conf.sh
@@ -1,42 +1,22 @@
 #!/bin/bash
 
- 
-#Initial conf for mysql
-mysql_install_db
-#for configuriing database
-/usr/bin/mysqld_safe &
+DEBIAN_FRONTEND=noninteractive apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y -q php7.0-gd zoneminder
 
- sleep 3s
+#to fix error relate to ip address of container apache2
+echo "ServerName localhost" | tee /etc/apache2/conf-available/fqdn.conf
+ln -s /etc/apache2/conf-available/fqdn.conf /etc/apache2/conf-enabled/fqdn.conf
 
- mysqladmin -u root password mysqlpsswd
- mysqladmin -u root -pmysqlpsswd reload
- mysqladmin -u root -pmysqlpsswd create zm
-
- echo "grant select,insert,update,delete on zm.* to 'zmuser'@localhost identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd
- echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd
- 
- DEBIAN_FRONTEND=noninteractive apt-get update
- DEBIAN_FRONTEND=noninteractive apt-get install -y -q php7.0-gd zoneminder
-
- mysql -u root -pmysqlpsswd < /usr/share/zoneminder/db/zm_create.sql
- 
- #to fix error relate to ip address of container apache2
- echo "ServerName localhost" | tee /etc/apache2/conf-available/fqdn.conf
- ln -s /etc/apache2/conf-available/fqdn.conf /etc/apache2/conf-enabled/fqdn.conf
- 
- #apache2 conf
+#apache2 conf
 a2enmod cgi
 a2enconf zoneminder
 chown -R www-data:www-data /usr/share/zoneminder/
 a2enmod rewrite
 adduser www-data video
- 
- #to clear some data before saving this layer ...a docker image
- rm -R /var/www/html
- rm /etc/apache2/sites-enabled/000-default.conf
- apt-get clean
- rm -rf /tmp/* /var/tmp/*
- rm -rf /var/lib/apt/lists/*
 
-killall mysqld
-sleep 3s
+#to clear some data before saving this layer ...a docker image
+rm -R /var/www/html
+rm /etc/apache2/sites-enabled/000-default.conf
+apt-get clean
+rm -rf /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/*

--- a/startup.sh
+++ b/startup.sh
@@ -10,6 +10,10 @@ chown www-data:www-data /var/run/zm
 
 #to fix problem with data.timezone that appear at 1.28.108 for some reason
 sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
+#if ZM_DB_HOST variable is provided in container use it as is, if not left as localhost
+sed  -i "s|ZM_DB_HOST=localhost|ZM_DB_HOST=${ZM_DB_HOST:-localhost}|" /etc/zm/zm.conf
+#if ZM_SERVER_HOST variable is provided in container use it as is, if not left 02-multiserver.conf unchanged
+if [ -v ZM_SERVER_HOST ]; then sed -i "s|#ZM_SERVER_HOST=|ZM_SERVER_HOST=${ZM_SERVER_HOST}|" /etc/zm/conf.d/02-multiserver.conf; fi
 
 #wait until MySQL container start
 sleep 45s
@@ -25,9 +29,9 @@ else
         #this only happends if -V was used and data was not from another container for that reason need to recreate the db.
         if [ ! -f /var/cache/zoneminder/dbcreated ]; then
           date > /var/cache/zoneminder/dbcreated
-          echo "grant select,insert,update,delete on zm.* to 'zmuser'@zm identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd -h db
-          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd -h db
-          mysql -u root -pmysqlpsswd -h db < /usr/share/zoneminder/db/zm_create.sql
+          echo "grant select,insert,update,delete on zm.* to 'zmuser'@zm identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost}
+          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost}
+          mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost} < /usr/share/zoneminder/db/zm_create.sql
         fi
         
         #check if Directory inside of /var/cache/zoneminder are present.

--- a/startup.sh
+++ b/startup.sh
@@ -10,25 +10,18 @@ if [ -f /etc/configured ]; then
 else
         #to fix problem with data.timezone that appear at 1.28.108 for some reason
         sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
-
+        sleep 45s
+        
         #configuration for zoneminder
         #trays to fix problem with https://github.com/QuantumObject/docker-zoneminder/issues/22
         chown www-data /dev/shm
         #cp /etc/mysql/mysql.conf.d/mysqld.cnf /usr/my.cnf
         #this only happends if -V was used and data was not from another container for that reason need to recreate the db.
-        if [ ! -f /var/lib/mysql/ibdata1 ]; then
-          mysql_install_db
-          #create database for zm
-          /usr/bin/mysqld_safe &
-          sleep 7s
-          mysqladmin -u root password mysqlpsswd
-          mysqladmin -u root -pmysqlpsswd reload
-          mysqladmin -u root -pmysqlpsswd create zm
-          echo "grant select,insert,update,delete on zm.* to 'zmuser'@localhost identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd
-          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd
-          mysql -u root -pmysqlpsswd < /usr/share/zoneminder/db/zm_create.sql
-          killall mysqld
-          sleep 5s
+        if [ ! -f /var/cache/zoneminder/dbcreated ]; then
+          date > /var/cache/zoneminder/dbcreated
+          echo "grant select,insert,update,delete on zm.* to 'zmuser'@zm identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd -h db
+          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd -h db
+          mysql -u root -pmysqlpsswd -h db < /usr/share/zoneminder/db/zm_create.sql
         fi
         
         #check if Directory inside of /var/cache/zoneminder are present.
@@ -39,7 +32,6 @@ else
         fi
         
         chown -R root:www-data /var/cache/zoneminder /etc/zm/zm.conf
-        chown -R mysql:mysql /var/lib/mysql 
         chmod -R 770 /var/cache/zoneminder /etc/zm/zm.conf
         
         #needed to fix problem with ubuntu ... and cron 

--- a/startup.sh
+++ b/startup.sh
@@ -7,15 +7,18 @@ set -e
 chown www-data /dev/shm
 mkdir -p /var/run/zm
 chown www-data:www-data /var/run/zm
+
 #to fix problem with data.timezone that appear at 1.28.108 for some reason
 sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
+
+#wait until MySQL container start
+sleep 45s
+
 if [ -f /var/cache/zoneminder/configured ]; then
         echo 'already configured'
         
         /sbin/zm.sh&
 else
-        #wait until MySQL container start
-        sleep 45s
         
         #configuration for zoneminder
         #cp /etc/mysql/mysql.conf.d/mysqld.cnf /usr/my.cnf

--- a/startup.sh
+++ b/startup.sh
@@ -3,18 +3,21 @@
 
 set -e
 
-if [ -f /etc/configured ]; then
+#trays to fix problem with https://github.com/QuantumObject/docker-zoneminder/issues/22
+chown www-data /dev/shm
+mkdir -p /var/run/zm
+chown www-data:www-data /var/run/zm
+#to fix problem with data.timezone that appear at 1.28.108 for some reason
+sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
+if [ -f /var/cache/zoneminder/configured ]; then
         echo 'already configured'
         
         /sbin/zm.sh&
 else
-        #to fix problem with data.timezone that appear at 1.28.108 for some reason
-        sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
+        #wait until MySQL container start
         sleep 45s
         
         #configuration for zoneminder
-        #trays to fix problem with https://github.com/QuantumObject/docker-zoneminder/issues/22
-        chown www-data /dev/shm
         #cp /etc/mysql/mysql.conf.d/mysqld.cnf /usr/my.cnf
         #this only happends if -V was used and data was not from another container for that reason need to recreate the db.
         if [ ! -f /var/cache/zoneminder/dbcreated ]; then
@@ -36,7 +39,7 @@ else
         
         #needed to fix problem with ubuntu ... and cron 
         update-locale
-        date > /etc/configured
+        date > /var/cache/zoneminder/configured
         
         /sbin/zm.sh&
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -11,7 +11,8 @@ chown www-data:www-data /var/run/zm
 #to fix problem with data.timezone that appear at 1.28.108 for some reason
 sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.0/apache2/php.ini
 #if ZM_DB_HOST variable is provided in container use it as is, if not left as localhost
-sed  -i "s|ZM_DB_HOST=localhost|ZM_DB_HOST=${ZM_DB_HOST:-localhost}|" /etc/zm/zm.conf
+ZM_DB_HOST=${ZM_DB_HOST:-localhost}
+sed  -i "s|ZM_DB_HOST=localhost|ZM_DB_HOST=$ZM_DB_HOST|" /etc/zm/zm.conf
 #if ZM_SERVER_HOST variable is provided in container use it as is, if not left 02-multiserver.conf unchanged
 if [ -v ZM_SERVER_HOST ]; then sed -i "s|#ZM_SERVER_HOST=|ZM_SERVER_HOST=${ZM_SERVER_HOST}|" /etc/zm/conf.d/02-multiserver.conf; fi
 
@@ -28,10 +29,19 @@ else
         #cp /etc/mysql/mysql.conf.d/mysqld.cnf /usr/my.cnf
         #this only happends if -V was used and data was not from another container for that reason need to recreate the db.
         if [ ! -f /var/cache/zoneminder/dbcreated ]; then
+          # IF ZM_DB_HOST is set to localhost, start MySQL local. If not MySQL is running in a separate container
+          if [ "$ZM_DB_HOST" == "localhost" ]; then
+            /usr/bin/mysqld_safe &
+            sleep 5s
+            echo "grant select,insert,update,delete on zm.* to 'zmuser'@localhost identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd -h $ZM_DB_HOST
+          fi
+          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd -h $ZM_DB_HOST
+          mysql -u root -pmysqlpsswd -h $ZM_DB_HOST < /usr/share/zoneminder/db/zm_create.sql
           date > /var/cache/zoneminder/dbcreated
-          echo "grant select,insert,update,delete on zm.* to 'zmuser'@zm identified by 'zmpass'; flush privileges; " | mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost}
-          echo "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" | mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost}
-          mysql -u root -pmysqlpsswd -h ${ZM_DB_HOST:-localhost} < /usr/share/zoneminder/db/zm_create.sql
+          if [ "$ZM_DB_HOST" == "localhost" ]; then
+            killall mysqld
+            sleep 5s
+          fi
         fi
         
         #check if Directory inside of /var/cache/zoneminder are present.


### PR DESCRIPTION
This enhancement provides the ability to run ZoneMinder in a separate container from MySQL and also with the functionality of running multiples copies of ZoneMinder host as is described in the architecture proposed for [MultiServer](http://zoneminder.readthedocs.io/en/latest/installationguide/multiserver.html) install .
At the README.md file there is a docker swarm stack example showing a multi server deployment with a container for a DB, a container with one replica for the frontend host and 3 replicas for capturing camera recording and streaming.
For doing that the startup script is looking for the environment variable ZM_SERVER_HOST which can be defined at docker-compose.yml file as node.{{.Task.Slot}}, multiples replicas of the container will generate values such as node.1 node.2 and son on.
Also as best practice on docker production deployment there is no usage of NTP (docker node responsibility) and backups which can be implemented outside the ZoneMinder container using [swarm scheduler](https://store.docker.com/community/images/rayyanqcri/swarm-scheduler). Here an example of a separate service for doing backup:
```
  backup:
    image: quantumobject/docker-zoneminder:1.31.1
    command: /sbin/backup
    networks:
      - net
    volumes:
      - backups:/var/backups
    environment:
      - ZM_DB_HOST=db
    deploy:
      mode: replicated
      replicas: 0
      placement:
        constraints:
          - node.labels.interconnect == si
      restart_policy:
        condition: none
```
Best regards, Marcelo.

