### PR TITLE
clean up var/run/zm before start

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -31,8 +31,8 @@ if [ -f /var/cache/zoneminder/configured ]; then
           sleep 3
           echo "waiting for mysql ..."
         done
-     
-        /sbin/zm.sh&
+        rm -rf /var/run/zm/* 
+	/sbin/zm.sh&
 else 
         #check if Directory inside of /var/cache/zoneminder are present.
         if [ ! -d /var/cache/zoneminder/events ]; then
@@ -50,5 +50,6 @@ else
         update-locale
         date > /var/cache/zoneminder/configured
         zmupdate.pl
+        rm -rf /var/run/zm/* 
         /sbin/zm.sh&
 fi

--- a/zm.sh
+++ b/zm.sh
@@ -4,5 +4,4 @@
 # If you omit that part, the command will be run as root.
 
 sleep 7s
- 
 exec chpst -u root /usr/bin/zmpkg.pl start >>/var/log/zm/zm.log 2>&1


### PR DESCRIPTION
this is needed because when I do a docker restart this leaves a zmaudit.pid which doesn't let the zmaudit run on the subsequent restart. 