### PR TITLE
increase the memory limit of php

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -8,6 +8,8 @@ chown www-data /dev/shm
 mkdir -p /var/run/zm
 chown www-data:www-data /var/run/zm
 
+# set the memory limit of php
+sed  -i "s|memory_limit = .*|memory_limit = ${PHP_MEMORY_LIMIT:-512M}|" /etc/php/7.2/apache2/php.ini
 #to fix problem with data.timezone that appear at 1.28.108 for some reason
 sed  -i "s|\;date.timezone =|date.timezone = \"${TZ:-America/New_York}\"|" /etc/php/7.2/apache2/php.ini
 #if ZM_DB_HOST variable is provided in container use it as is, if not left as localhost


### PR DESCRIPTION
setting the memory_limit in php.ini to 512M, it will also accept another value by setting PHP_MEMORY_LIMIT

https://github.com/ZoneMinder/zoneminder/issues/2400